### PR TITLE
Make intercept calculation optional in Linear Regression.  Add test and precondition

### DIFF
--- a/src/clatern/linear_regression.clj
+++ b/src/clatern/linear_regression.clj
@@ -1,29 +1,52 @@
 (ns clatern.linear-regression
   (:require [clojure.core.matrix :refer :all]
-            [clojure.core.matrix.dataset :refer :all]))
+            [clojure.core.matrix.dataset :refer :all]
+            [clojure.core.matrix.linear :refer :all]))
 
 ;; Ordinary Least Squares
 ;; ======================
 ;;  X : input data
 ;;  y : target data
 
-(defn- predict [coefs v]
-  {:pre [(= (count coefs) (+ 1 (count v)))]}
-  (let [v_1 (conj v 1)
-        product (map * v_1 coefs)]
-    (reduce + product)))
+(defn- center-data [X y fit-intercept]
+  (let [n-samples (dimension-count X 0)
+        n-features (dimension-count X 1)]
+    (if fit-intercept
+      (let [X-mean (emul (reduce add (rows X)) (/ 1.0 n-features))
+            X-centered (sub X X-mean)
+            y-mean (emul (esum y) (/ 1.0 n-samples))
+            y-centered (sub y y-mean)]
+        [X-centered y-centered X-mean y-mean])
+      (let [X-mean (zero-vector n-samples)
+            y-mean 0]
+        [X y X-mean y-mean]))))
 
-(defrecord LinearRegression [coefs]
+(defn- compute-intercept [X-mean y-mean coefs fit-intercept]
+  (if fit-intercept
+    (sub y-mean (dot X-mean (transpose coefs)))
+    0.0))
+        
+(defn- predict [coefs intercept v]
+  (+ (mmul coefs v) intercept))
+
+(defrecord LinearRegression [coefs intercept]
   clojure.lang.IFn
-  (invoke [this v] (predict coefs v))
+  (invoke [this v] (predict coefs intercept v))
   (applyTo [this args] (clojure.lang.AFn/applyToHelper this args)))
 
-(defn ols [X y]
-  (let [X_1 (join-along 1 (transpose [(repeat (row-count X) 1)]) X)
-        Xt (transpose X_1)
-        Xt-X (mmul Xt X_1)
-        coefs (matrix (mmul (inverse Xt-X) Xt y))]
-    (LinearRegression. coefs)))
+(defn ols [X y & {:keys [fit-intercept]
+                  :or {fit-intercept false}}]
+  {:pre [(let [X-rows (dimension-count X 0)
+               X-columns (dimension-count X 1)]
+           (if fit-intercept
+             (> X-rows X-columns)
+             (>= X-rows X-columns)))]}
+  (let [[X-centered y-centered X-mean y-mean] (center-data X y fit-intercept)
+        Xt (transpose X-centered)
+        Xt-X (mmul Xt X-centered)
+        coefs (matrix (mmul (inverse Xt-X) Xt y-centered))
+        intercept (compute-intercept X-mean y-mean coefs fit-intercept)]
+    (LinearRegression. coefs intercept)))
 
 
 ;; TODO: implement gradient descent support 

--- a/test/clatern/linear_regression_test.clj
+++ b/test/clatern/linear_regression_test.clj
@@ -1,0 +1,42 @@
+(ns clatern.linear-regression-test
+  (:require [clojure.test :refer :all]
+            [clatern.linear-regression :refer :all]
+            [clojure.core.matrix :refer :all]
+            [clojure.core.matrix.linear :refer :all]))
+
+(def epsilon 1e-5)
+
+(defn- vec= [x y eps]
+  (< (norm (sub x y)) eps))
+  
+(deftest test-linear-regression
+  (testing "with intercepts"
+    (let [X [[1 0 0]
+             [0 1 0]
+             [0 0 1]
+             [1 1 1]]
+          y [1.0 3.0 5.0 3.0]
+          model (ols X y :fit-intercept true)
+          coefs (:coefs model)
+          intercept (:intercept model)]
+      (is (= (count coefs) (dimension-count X 1)))
+      (is (vec= coefs [-2.0 0.0 2.0] epsilon))
+      (is (= intercept 3.0))
+      (is (= (model [1 0 0]) 1.0))
+      (is (= (model [0 1 0]) 3.0))
+      (is (= (model [0 0 1]) 5.0))))
+
+  (testing "without intercepts"
+    (let [X [[1 0 0]
+             [0 1 0]
+             [0 0 1]]
+          y [1.0 3.0 5.0]
+          model (ols X y :fit-intercept false)
+          coefs (:coefs model)
+          intercept (:intercept model)]
+      (is (= (count coefs) (dimension-count X 1)))
+      (is (vec= coefs [1.0 3.0 5.0] epsilon))
+      (is (= intercept 0.0))
+      (is (= (model [1 0 0]) 1.0))
+      (is (= (model [0 1 0]) 3.0))
+      (is (= (model [0 0 1]) 5.0)))))


### PR DESCRIPTION
Following the approach used in scikit-learn, I made the calculation of the intercept optional in the Linear Regression.  I added a test covering both cases and a precondition that verifies that we have enough vectors.
