### PR TITLE
Issue #6. Make kNN interface consistent with other classifiers

### DIFF
--- a/src/clatern/knn.clj
+++ b/src/clatern/knn.clj
@@ -9,8 +9,7 @@
 ;;  v : new input to be classified
 ;;  k : number of neighbours
 
-(defn knn [X y v & {:keys [k]
-                      :or {k 3}}]
+(defn- predict [X y v k]
   (->> (map vector (map  #(distance % v) X)  y)       
        (sort-by first)
        (take k)
@@ -19,3 +18,13 @@
        (sort-by val)
        (last)
        (first)))
+
+(defrecord kNN [X y k]
+  clojure.lang.IFn
+  (invoke [this v] (predict X y v k))
+  (applyTo [this args] (clojure.lang.AFn/applyToHelper this args)))
+
+(defn knn [X y & {:keys [k]
+                      :or {k 3}}]
+  (kNN. X y k))
+  

--- a/test/clatern/knn_test.clj
+++ b/test/clatern/knn_test.clj
@@ -9,9 +9,12 @@
              [0 1 0 0]
              [1 0 0 0]]
           y [0 1 0 1]
-          v1 [0 0 0 0.95]
-          y1 (knn X y v1 :k 1)
+          v [0 0 0 0.95]
+          k 1
+          model (knn X y :k k)
+          y1 (model v)
           expected 0]
+      (is (= (:k model) k))
       (is (= y1 expected))))
 
   (testing "k=3"
@@ -20,8 +23,11 @@
              [0 1 0 0]
              [1 0 0 0]]
           y [0 1 0 1]
-          v1 [0 0.95 0.95 0.95]
-          y1 (knn X y v1 :k 3)
+          v [0 0.95 0.95 0.95]
+          k 3
+          model (knn X y :k k)
+          y1 (model v)
           expected 0]
+      (is (= (:k model) k))
       (is (= y1 expected)))))
 


### PR DESCRIPTION
1. Changes signature of `knn` so that `v` (vector to classify) is not longer taken.
2. `knn` now returns a `kNN` record that implements `IFn`. The record stores `X`, `y`, and `k`.  The record's only function calls `predict`.
3. Moved main code in `knn` to a namespace-private `predict` function
