### PR TITLE
Fix linear regression to handle vectors correctly.  Add support for p…

### DIFF
--- a/src/clatern/linear_regression.clj
+++ b/src/clatern/linear_regression.clj
@@ -8,10 +8,18 @@
 ;;  y : target data
 
 (defn- predict [coefs v]
-  {:pre [(= (count coefs) (+ 1 (count v)))]}
-  (let [v_1 (conj v 1)
-        product (map * v_1 coefs)]
-    (reduce + product)))
+  {:pre [(let [ncoefs (dimension-count coefs 0)
+               lastdim (- (dimensionality v) 1)]
+           (or (= lastdim 0)
+               (= lastdim 1))
+           (= ncoefs (+ 1 (dimension-count v lastdim))))]}
+  (let [ndim (dimensionality v)
+        vs (if (= ndim 1) [v] v)
+        v_1 (join-along 1 (transpose [(repeat (row-count vs) 1)]) vs)
+        y (mmul v_1 coefs)]
+    (if (= ndim 1)
+      (mget y 0)
+      y)))
 
 (defrecord LinearRegression [coefs]
   clojure.lang.IFn

--- a/test/clatern/linear_regression_test.clj
+++ b/test/clatern/linear_regression_test.clj
@@ -1,0 +1,23 @@
+(ns clatern.linear-regression-test
+  (:require [clojure.test :refer :all]
+            [clojure.core.matrix :refer :all]
+            [clatern.test-utils :refer :all]
+            [clatern.linear-regression :refer :all]))
+
+(deftest test-linear-regression
+  (testing "linear regression on vector"
+    (let [X [[1 0 0]
+             [0 1 0]
+             [0 0 1]
+             [1 1 1]]
+          y [1 3 5 7]
+          model (ols X y)]
+      ; test predictions on individual vectors
+      (loop [i 0]
+        (if (< i (dimension-count X 0))
+          (let [v (slice X i)
+                y1 (slice y i)]
+                (is (float-equals (model v) y1 eps))
+                (recur (inc i)))))
+      ; test predictions on multiple vectors
+      (is (vector-equals (model X) y eps)))))

--- a/test/clatern/metrics_test.clj
+++ b/test/clatern/metrics_test.clj
@@ -1,13 +1,7 @@
 (ns clatern.metrics-test
   (:require [clojure.test :refer :all]
+            [clatern.test-utils :refer :all]
             [clatern.metrics :refer :all]))
-
-(def eps 1e-5)
-
-(defn- float-equals
-  "Compare floats within epsilon"
-  [x y eps]
-  (< (Math/abs (- x y)) eps))
 
 (deftest test-equal-vectors
   (testing "Equal vectors"

--- a/test/clatern/test_utils.clj
+++ b/test/clatern/test_utils.clj
@@ -1,0 +1,15 @@
+(ns clatern.test-utils
+  (:require [clojure.core.matrix :refer :all]
+            [clojure.core.matrix.linear :refer [norm]]))
+
+(def eps 1e-5)
+
+(defn float-equals
+  "Compare floats within epsilon"
+  [x y eps]
+  (< (Math/abs (- x y)) eps))
+
+(defn vector-equals
+  "Compare vectors or matrices of floats within epsilon"
+  [v1 v2 eps]
+  (< (norm (sub v1 v2)) eps))


### PR DESCRIPTION
…redictions on vectors or matrix. Move float-equals to new test-utils module.  Add vector-equals. Update linear regression test to incorporate vector and matrix predictions. Closes #15 and #21.

This version preserves the position of the intercept as the first element in the coefficients.  We now wrap vectors as matrices, perform the multiple, and unpack the results.
