### PR TITLE
Add function for reassigning points to empty clusters.  

### DIFF
--- a/src/clatern/kmeans.clj
+++ b/src/clatern/kmeans.clj
@@ -1,5 +1,6 @@
 (ns clatern.kmeans
-  (:require [clojure.core.matrix :refer :all]
+  (:require [clojure.set :refer [difference]]
+            [clojure.core.matrix :refer :all]
             [clojure.core.matrix.dataset :refer :all]
             [clojure.core.matrix.operators :as M]))
 
@@ -33,23 +34,43 @@
             X-this (map #(nth X %) indices)]
         (conj [] i (calc-centroid X-this))))))
 
-(defn- cluster-assign
-  "Assign clusters to all data items"
-  [X centroids]
-  (let [cs (map last (seq centroids))
-        distances (map #(calculate-distances X %) cs)]
-    (map #(first (apply min-key second (map-indexed vector %))) (columns distances))))
-
 (defn- assign-cluster
   "Assign cluster for a new vector"
   [centroids v]
-  (let [cs (map last (seq centroids))
-        distances (calculate-distances cs v)]
-    (first (apply min-key second (map-indexed vector distances)))))
+  (let [centroid-distances (for [[idx centroid] centroids] [idx (distance centroid v)])]
+  (apply min-key second centroid-distances)))
+
+(defn- cluster-assign
+  "Assign clusters to all data items"
+  [X centroids]
+  (map #(assign-cluster centroids %) (rows X)))
+
+(defn- reassign-if-necessary
+  "Reassigns outlier points to empty clusters so that no clusters are empty"
+  [X assignments k]
+  ; assignments is seq of [cluster-idx distance]
+  (let [assigned-cluster-ids (set (map first assignments))]
+    (if (= (count assigned-cluster-ids) k)
+      assignments
+            ; seq of [pt-idx [cluster-idx distance]]
+      (let [indexed-assignments (map-indexed vector assignments)
+            ; sorted by dist descending
+            sorted-assignments (sort-by #(- (last (last %))) indexed-assignments)
+            missing-cluster-ids (difference (set (range k)) assigned-cluster-ids)
+            n-missing (count missing-cluster-ids)
+            point-ids-to-reassign (map first (take n-missing sorted-assignments))
+            reassigned (into {} (map vector point-ids-to-reassign missing-cluster-ids))
+            ; replace elements in original assignments
+            indexed-reassignments (map #(if (contains? reassigned (first %))
+                                            [(first %) [(reassigned (first %)) 0.0]] %)
+                                         indexed-assignments)
+            reassignments (map last indexed-reassignments)]
+        reassignments))))
+            
 
 (defrecord kMeans [centroids]
   clojure.lang.IFn
-  (invoke [this v] (assign-cluster centroids v))
+  (invoke [this v] (first (assign-cluster centroids v)))
   (applyTo [this args] (clojure.lang.AFn/applyToHelper this args)))
 
 (defn kmeans [X & {:keys [k num-iters]
@@ -58,10 +79,11 @@
   (let [n (column-count X)
         lim (row-count X)
         init-centroids (map-indexed vector (rand-centroids X k lim))
-        centroids (loop [i 0 centroids init-centroids output (repeat lim 0)]
-                   (if (= i num-iters)
-                     centroids
-                     (let [new-output (cluster-assign X centroids)
-                           new-centroids (move-centroids X new-output centroids)]
-                       (recur (inc i) new-centroids new-output))))]
+        centroids (loop [i 0 centroids init-centroids]
+                    (if (= i num-iters)
+                      centroids
+                      (let [assignments (cluster-assign X centroids)
+                            reassignments (map first (reassign-if-necessary X assignments k))
+                            new-centroids (move-centroids X reassignments centroids)]
+                        (recur (inc i) new-centroids))))]
     (kMeans. centroids)))

--- a/test/clatern/kmeans_test.clj
+++ b/test/clatern/kmeans_test.clj
@@ -12,15 +12,10 @@
           X (into (take 3 (repeat v1))
                     (into (take 3 (repeat v2))
                     (take 3 (repeat v3))))
-          clusters (kmeans X)
+          clusters (kmeans X :num-iters 10)
           centers (mapv #(get % 1) (:centroids clusters))]
       (is (= (count centers) 3))
-      ; we either get: (a) one cluster at each group if
-      ; each cluster is initialized to a separate point
-      ; or (b) a single cluster and two empty clusters if
-      ; clusters are initialized with the equal points
-      (is (or (and (not= -1 (.indexOf centers v1))
-                   (not= -1 (.indexOf centers v2))
-                   (not= -1 (.indexOf centers v3)))
-              (and (not= -1 (.indexOf centers [1/3 1/3 1/3]))
-                   (not= -1 (.indexOf centers []))))))))
+      (is (and (not= -1 (.indexOf centers v1))
+               (not= -1 (.indexOf centers v2))
+               (not= -1 (.indexOf centers v3)))))))
+


### PR DESCRIPTION
KMeans can produce empty clusters.  To solve this, I used the same approach as scikit-learn: reassign the points with the largest distances to the empty clusters.  Additionally, I removed an unnecessary variable from the KMeans main loop, refactored the cluster-assign / assign-cluster functions to remove duplicate code, and removed the acceptance condition for empty clusters in the test. Closes #3 .
