### PR TITLE
Parameterize distance metrics in KMeans. Closes #27

### DIFF
--- a/test/clatern/kmeans_test.clj
+++ b/test/clatern/kmeans_test.clj
@@ -2,18 +2,34 @@
   (:require [clojure.test :refer :all]
             [clatern.kmeans :refer :all]
             [clojure.core.matrix :refer :all]
-            [clojure.core.matrix.operators :as M]))
+            [clojure.core.matrix.operators :as M]
+            [clatern.metrics :refer :all]))
+
+(def v1 [0 0 1])
+(def v2 [0 1 0])
+(def v3 [1 0 0])
+(def X [v1 v1 v1 v2 v2 v2 v3 v3 v3])
 
 (deftest test-three-clusters
   (testing "three clusters"
-    (let [v1 [0 0 1]
-          v2 [0 1 0]
-          v3 [1 0 0]
-          X (into (take 3 (repeat v1))
-                    (into (take 3 (repeat v2))
-                    (take 3 (repeat v3))))
-          clusters (kmeans X :num-iters 10)
-          centers (mapv #(get % 1) (:centroids clusters))]
+    (let [clusters (kmeans X :num-iters 10)
+          centers (mapv second (:centroids clusters))]
+      (is (= (count centers) 3))
+      (is (and (not= -1 (.indexOf centers v1))
+               (not= -1 (.indexOf centers v2))
+               (not= -1 (.indexOf centers v3))))))
+
+  (testing "three clusters with cosine distance"
+    (let [clusters (kmeans X :num-iters 10 :dist-metric cosine-distance)
+          centers (mapv second (:centroids clusters))]
+      (is (= (count centers) 3))
+      (is (and (not= -1 (.indexOf centers v1))
+               (not= -1 (.indexOf centers v2))
+               (not= -1 (.indexOf centers v3))))))
+
+  (testing "three clusters with manhattan distance"
+    (let [clusters (kmeans X :num-iters 10 :dist-metric manhattan-distance)
+          centers (mapv second (:centroids clusters))]
       (is (= (count centers) 3))
       (is (and (not= -1 (.indexOf centers v1))
                (not= -1 (.indexOf centers v2))


### PR DESCRIPTION
Add distance metric as an optional parameter to KMeans.  Use
Euclidean distance as a default for API compatibility.  Clean
up KMeans tests for readability and add tests with more
distance metrics. Closes #27 
