### PR TITLE
Add functionality to decision trees in preparation for adding Random Forests

### DIFF
--- a/src/clatern/decision_tree.clj
+++ b/src/clatern/decision_tree.clj
@@ -1,6 +1,7 @@
 (ns clatern.decision-tree
   (:refer-clojure :exclude [partition])
   (:require [clojure.set :refer [union]]
+            [clatern.protocols :refer [ClassProbabilityEstimator]]
             [clojure.core.matrix :refer :all]))
 
 (defn- map-values
@@ -66,11 +67,13 @@
   split which minimizes the cost.
 
   `X` is a `n_samples` x `n_features` feature matrix. `y` is a vector of
-  labels.  `elems` is a vector of sample indices to use."
-  [X y elems]
-  (let [n_samples (count elems)
-        n_features (dimension-count X 1)
-        feature-optimal-thresholds (for [idx (range n_features)]
+  labels.  `feature-sampler` is a function that takes the number of features
+  and returns a sequence of feature indices. `elems` is a vector of sample
+  indices to use."
+  [X y sample-features elems]
+  (let [n-features (dimension-count X 1)
+        features (sample-features n-features)
+        feature-optimal-thresholds (for [idx features]
                                      [idx (find-optimal-threshold X y elems idx)])
         [feature-idx [threshold cost left right]] (apply min-key #(second (second %))
                                                          feature-optimal-thresholds)]
@@ -94,45 +97,83 @@
   labels `y`.
 
   `X` is a `n_samples` x `n_features` feature matrix. `y` is a vector of labels.
-  `max-depth` is the maximum depth of the tree."
-  ([X y max-depth]
-   (train-tree X y max-depth 1 (range (count y))))
-  ([X y max-depth depth elems]
+  `max-depth` is the maximum depth of the tree. `feature-sampler` is a function
+  that takes the number of features and returns a sequence of feature indices.
+  `elems` is a list of sample indices to train the tree on -- indices can appear
+  multiple times."
+  ([X y max-depth feature-sampler elems]
+   (train-tree X y max-depth 1 feature-sampler elems))
+  ([X y max-depth depth feature-sampler elems]
    (let [n-elems (count elems)
-         [feature-idx threshold cost left right] (find-best-split X y elems)
-         label-counts (frequencies (map y elems))]
+         [feature-idx threshold cost left right] (find-best-split X y feature-sampler elems)
+         default-counts (into {} (map #(vector % 0) y))
+         label-counts (merge default-counts (frequencies (map y elems)))]
      (if (split-node? y max-depth (inc depth) left right)
        {:type :internal,
         :threshold threshold,
         :feature-idx feature-idx,
-        :left (train-tree X y max-depth (inc depth) left),
-        :right (train-tree X y max-depth (inc depth) right)}
+        :left (train-tree X y max-depth (inc depth) feature-sampler left),
+        :right (train-tree X y max-depth (inc depth) feature-sampler right)}
        {:label-counts label-counts,
         :type :leaf}))))
 
-(defn- predict
-  "Predicts the class of vector `v` based on decision tree `tree`."
+(defn- find-leaf-node
+  "Find leaf node for vector `v` in the decision tree `tree`."
   [tree v]
   (if (= (tree :type) :leaf)
-    (first (apply max-key second (tree :label-counts)))
+    tree
     (let [{feature-idx :feature-idx,
            threshold :threshold} tree
            feature-value (v feature-idx)
            child (if (<= feature-value threshold) :left :right)]
-      (predict (tree child) v))))
+      (find-leaf-node (tree child) v))))
+
+(defn- normalize
+  "Normalize counts"
+  [label-counts]
+  (let [leaf-elems (reduce + (vals label-counts))]
+    (map-values #(/ % leaf-elems) label-counts)))
+
+(defn- predict
+  "Predicts the class of vector `v` using a majority vote of the class distribution
+  from the leaf of a decision tree `tree`."
+  [tree v]
+  (let [leaf (find-leaf-node tree v)]
+    (first (apply max-key second (leaf :label-counts)))))
+
+(defn- predict-prob
+  "Predicts the class label probability distribution for the vector `v`."
+  [tree v]
+  (let [leaf (find-leaf-node tree v)]
+        (normalize (leaf :label-counts))))
+
+(defn- predict-log-prob
+  "Predicts the class label log probabilities for the vector `v`."
+  [tree v]
+  ; prevent log(0)
+  (map-values #(java.lang.Math/log (+ % 0.000001)) (predict-prob tree v)))
 
 (defrecord DecisionTree [tree]
   clojure.lang.IFn
   (invoke [this v] (predict tree v))
-  (applyTo [this args] (clojure.lang.AFn/applyToHelper this args)))
+  (applyTo [this args] (clojure.lang.AFn/applyToHelper this args))
+
+  ClassProbabilityEstimator
+  (predict-prob [this v] (predict-prob tree v))
+  (predict-log-prob [this v] (predict-log-prob tree v)))
       
 (defn decision-tree
   "Trains decision tree and returns model.
 
+  Implementation of the CART algorithm that uses Gini impurity to determine
+  the best splits and majority vote on the leaves' class label distributions
+  for predictions.  
+
   `X` is a `n_samples` x `n_features` feature matrix. `y` is a vector of a
   class labels. `max-depth` is optional (default 5) and controls the
-  maximum height of the tree."
-  [X y & {:keys [max-depth]
-          :or {max-depth 5}}]
-  (let [tree (train-tree X y max-depth)]
+  maximum height of the tree. `elems` is an (optional) list of samples to
+  use to train the tree -- indices can occur multiple times."
+  [X y & {:keys [max-depth elems]
+          :or {max-depth 5 elems (range (count y))}}]
+  (let [tree (train-tree X y max-depth range elems)]
     (DecisionTree. tree)))

--- a/src/clatern/protocols.clj
+++ b/src/clatern/protocols.clj
@@ -1,0 +1,7 @@
+(ns clatern.protocols)
+
+(defprotocol ClassProbabilityEstimator
+  "Protocol for classifiers that can estimate
+   class probabilities for a sample vector."  
+  (predict-prob [this v] "Predict class probabilities for `v`.")
+  (predict-log-prob [this v] "Predict class log probabilities for `v`."))

--- a/test/clatern/decision_tree_test.clj
+++ b/test/clatern/decision_tree_test.clj
@@ -1,6 +1,7 @@
 (ns clatern.decision-tree-test
   (:require [clojure.test :refer :all]
             [clatern.decision-tree :refer :all]
+            [clatern.protocols :refer [predict-prob predict-log-prob]]
             [clatern.test-utils :refer :all]))
 
 (deftest test-gini
@@ -24,7 +25,6 @@
           expected 1.0
           observed (#'clatern.decision-tree/gini-impurity y indices)]
       (is (float-equals expected observed eps)))))
-
 
 
 (deftest test-find-optimal-threshold
@@ -68,7 +68,7 @@
           y [0 0 0 1 1 1]
           indices (range (count y))
           [feature-idx threshold cost left right] (#'clatern.decision-tree/find-best-split
-                                                   X y indices)
+                                                   X y range indices)
           expected-cost 0.0
           expected-idx 0
           expected-threshold 2]
@@ -126,11 +126,11 @@
              [4]]
           y [0 0 1 1]
           max-depth 3
-          tree (#'clatern.decision-tree/train-tree X y max-depth)]
+          tree (#'clatern.decision-tree/train-tree X y max-depth range (range (count y)))]
       (is (= (get-in tree [:left :type] :leaf)))
       (is (= (get-in tree [:right :type] :leaf)))
-      (is (= (count (get-in tree [:left :label-counts])) 1))
-      (is (= (count (get-in tree [:right :label-counts])) 1))
+      (is (= (get-in tree [:left :label-counts]) {0 2, 1 0}))
+      (is (= (get-in tree [:right :label-counts]) {0 0, 1 2}))
       (is (= (get-in tree [:threshold]) 2))))
 
   (testing "2 classes, 2 features, 4 clusters"
@@ -144,15 +144,15 @@
              [1 1]]
           y [0 0 1 1 1 1 0 0]
           max-depth 3
-          tree (#'clatern.decision-tree/train-tree X y max-depth)]
+          tree (#'clatern.decision-tree/train-tree X y max-depth range (range (count y)))]
       (is (= (get-in tree [:left :left :type] :leaf)))
       (is (= (get-in tree [:left :right :type] :leaf)))
       (is (= (get-in tree [:right :left :type] :leaf)))
       (is (= (get-in tree [:right :right :type] :leaf)))
-      (is (= (count (get-in tree [:left :left :label-counts])) 1))
-      (is (= (count (get-in tree [:left :right :label-counts])) 1))
-      (is (= (count (get-in tree [:right :left :label-counts])) 1))
-      (is (= (count (get-in tree [:right :right :label-counts])) 1))
+      (is (= (get-in tree [:left :left :label-counts]) {0 2, 1 0}))
+      (is (= (get-in tree [:left :right :label-counts]) {0 0, 1 2}))
+      (is (= (get-in tree [:right :left :label-counts]) {0 0, 1 2}))
+      (is (= (get-in tree [:right :right :label-counts]) {0 2, 1 0}))
       (is (= (get-in tree [:threshold]) 0))
       (is (= (get-in tree [:left :threshold]) 0))
       (is (= (get-in tree [:right :treshold] 0))))))
@@ -173,9 +173,52 @@
           v3 [1 0]
           v4 [1 1]
           max-depth 3
-          dt (decision-tree X y)]
+          dt (decision-tree X y)
+          prob-v1 (predict-prob dt v1)
+          prob-v2 (predict-prob dt v2)
+          log-prob-v1 (predict-log-prob dt v1)
+          log-prob-v2 (predict-log-prob dt v2)]
       (is (some? (:tree dt)))
       (is (= (dt v1) 0))
       (is (= (dt v2) 1))
       (is (= (dt v3) 1))
-      (is (= (dt v4) 0)))))
+      (is (= (dt v4) 0))
+      (is (and 
+           (float-equals (prob-v1 0) 1.0 eps)
+           (float-equals (prob-v1 1) 0.0 eps)))
+      (is (and 
+           (float-equals (prob-v2 1) 1.0 eps)
+           (float-equals (prob-v2 0) 0.0 eps)))
+      (is (and 
+           (float-equals (log-prob-v1 0) 0.0 eps)
+           (< (log-prob-v1 1) (java.lang.Math/log eps))))
+      (is (and 
+           (float-equals (log-prob-v2 1) 0.0 eps)
+           (< (log-prob-v2 0) (java.lang.Math/log eps))))))
+
+  (testing "2 classes, 2 features, 4 clusters with elements specified"
+    (let [X [[0 0]
+             [0 0]
+             [0 1]
+             [0 1]
+             [1 0]
+             [1 0]
+             [1 1]
+             [1 1]]
+          y [0 0 1 1 1 1 0 0]
+          v1 [0 0]
+          v2 [0 1]
+          v3 [1 0]
+          v4 [1 1]
+          max-depth 3
+          dt (decision-tree X y :elems [0 1 2 3])
+          prob-v1 (predict-prob dt v1)
+          prob-v2 (predict-prob dt v2)]
+      (is (some? (:tree dt)))
+      (is (= (dt v1) 0))
+      (is (= (dt v2) 1))
+      (is (= (dt v3) 0))
+      (is (= (dt v4) 1))
+      (is (float-equals (prob-v1 0) 1.0 eps))
+      (is (float-equals (prob-v2 1) 1.0 eps)))))
+      


### PR DESCRIPTION
Changes include:
- Add optional parameter for function for choosing features to calculate splits on
- Add optional parameters for list of element indices to use in training
- Add ClassProbabilityEstimator protocol with predict-prob and predict-log-prob functions
- Extend documentation with more algorithm details
- Refactor internal predict functions
